### PR TITLE
Linted your yaml files

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,34 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  document-start:
+    present: true
+  document-end:
+    present: true
+  key-duplicates: enable
+  trailing-spaces: enable
+  new-line-at-end-of-file: disable
+  hyphens:
+    max-spaces-after: 1
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ linux_nagios_ip: 10.20.20.27
 linux_nagios_port: 5666
 
 ssl_certs: []
+...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,3 +9,4 @@
 
 - name: linux_ssl_update_certs
   command: update-ca-certificates
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
     - system
 
 dependencies: []
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,10 +6,10 @@ galaxy_info:
   license: GPLv3
   min_ansible_version: 2.0
   platforms:
-  - name: Ubuntu
-    versions:
-    - trusty
-    - xenial
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
   galaxy_tags:
     - ubuntu
     - system

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,3 +1,4 @@
+---
 - name: Configure the firewall (ssh)
   ufw: rule=allow port=ssh
 
@@ -9,3 +10,4 @@
 
 - name: Enable the firewall
   ufw: state=enabled policy=deny
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,15 +11,15 @@
         groups=staff
         append=yes
 
-#start with just updating the apt cache
+# start with just updating the apt cache
 - name: Update apt cache
   apt: update_cache=yes
 
-#get this so we can use it for upgrade:
+# get this so we can use it for upgrade:
 - name: Make sure aptitude is availabe for full upgrade
   apt: name=aptitude state=present
 
-#http://docs.ansible.com/ansible/apt_module.html
+# http://docs.ansible.com/ansible/apt_module.html
 - name: Full upgrade
   apt: upgrade=full
 
@@ -70,3 +70,4 @@
 #   - { regexp: '\"\$\{distro_id\}\:\$\{distro_codename\}-updates\"\;', line: '    "${distro_id}:${distro_codename}-updates";' }
 #   - { regexp: 'Unattended-Upgrade\:\:Remove-Unused-Dependencies',     line: 'Unattended-Upgrade::Remove-Unused-Dependencies \"true\";' }
 #   - { regexp: 'Unattended-Upgrade\:\:Automatic-Reboot \"',            line: 'Unattended-Upgrade::Automatic-Reboot \"true\";' }
+...

--- a/tasks/nano.yml
+++ b/tasks/nano.yml
@@ -1,11 +1,13 @@
+---
 - name: Add syntax file for Conf files
   copy: src=nano/conf.nanorc dest=/usr/share/nano/conf.nanorc
 
 - name: Apply Nano config
   lineinfile: dest=/etc/nanorc regexp="{{ item.regexp }}" line="{{ item.line }}"
   with_items:
-  - { regexp: 'set tabsize',      line: 'set tabsize 4' }
-  - { regexp: 'set tabstospaces', line: 'set tabstospaces' }
+  - {regexp: 'set tabsize', line: 'set tabsize 4'}
+  - {regexp: 'set tabstospaces', line: 'set tabstospaces'}
 
 - name: Setup Nano tabs and colors
   lineinfile: dest=/etc/nanorc insertafter='include "/usr/share/nano/c.nanorc"' line='include "/usr/share/nano/conf.nanorc"'
+...

--- a/tasks/ntp.yml
+++ b/tasks/ntp.yml
@@ -39,4 +39,4 @@
     name: ntp
     state: started
     enabled: yes
-
+...

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -9,3 +9,4 @@
   with_items: "{{ ssl_certs | default([]) }}"
   no_log: True
   notify: linux_ssl_update_certs
+...

--- a/tasks/vim.yml
+++ b/tasks/vim.yml
@@ -1,12 +1,13 @@
-- name: Set VIM as default editor 
+---
+- name: Set VIM as default editor
   file: src=/usr/bin/vim.basic dest=/etc/alternatives/editor state=link
 
 - name: Creating colors folder
   file: path=/etc/vim/colors state=directory
 
 - name: Copying vimrc.local file
-  copy: src=vim/vimrc.local dest=/etc/vim/vimrc.local 
+  copy: src=vim/vimrc.local dest=/etc/vim/vimrc.local
 
 - name: Copying vim color scheme file
-  copy: src=vim/darkdot.vim dest=/etc/vim/colors/darkdot.vim 
-
+  copy: src=vim/darkdot.vim dest=/etc/vim/colors/darkdot.vim
+...


### PR DESCRIPTION
I hope you'll accept a pass through the yaml linter. https://github.com/adrienverge/yamllint

I rely on that tool for my daily ansible workflow.

```
$ find . -type f -name "*.yml*" | sed "s|\./||g" | egrep -v "(\.kitchen/|\[warning\]|\.molecule/)" | xargs yamllint -f parsable
meta/main.yml:9:3: [error] wrong indentation: expected 4 but found 2 (indentation)
meta/main.yml:11:5: [error] wrong indentation: expected 6 but found 4 (indentation)
meta/main.yml:17:17: [error] no new line character at the end of file (new-line-at-end-of-file)
tasks/firewall.yml:1:1: [warning] missing document start "---" (document-start)
tasks/main.yml:14:2: [warning] missing starting space in comment (comments)
tasks/main.yml:18:2: [warning] missing starting space in comment (comments)
tasks/main.yml:22:2: [warning] missing starting space in comment (comments)
tasks/nano.yml:1:1: [warning] missing document start "---" (document-start)
tasks/nano.yml:7:6: [error] too many spaces inside braces (braces)
tasks/nano.yml:7:34: [error] too many spaces after comma (commas)
tasks/nano.yml:7:56: [error] too many spaces inside braces (braces)
tasks/nano.yml:8:6: [error] too many spaces inside braces (braces)
tasks/nano.yml:8:59: [error] too many spaces inside braces (braces)
tasks/ntp.yml:42:1: [error] too many blank lines (1 > 0) (empty-lines)
tasks/vim.yml:1:1: [warning] missing document start "---" (document-start)
tasks/vim.yml:1:34: [error] trailing spaces (trailing-spaces)
tasks/vim.yml:8:54: [error] trailing spaces (trailing-spaces)
tasks/vim.yml:11:61: [error] trailing spaces (trailing-spaces)
tasks/vim.yml:12:1: [error] too many blank lines (1 > 0) (empty-lines)
```