### PR TITLE
Skip additional packages and unattended upgrades if those variables are not defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
   apt:
     name: "{{ linux_packages }}"
     state: "present"
+  when: "linux_packages is defined"
 
 
 - name: Setup Firewall

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,4 +87,5 @@
       
   - { regexp: 'Automatic-Reboot-Time',
       line: 'Unattended-Upgrade::Automatic-Reboot-Time "{{ linux_unattended_upgrade.automatic_reboot_time }}";'}
+  when: "linux_unattended_upgrade is defined"
 ...


### PR DESCRIPTION
This brings additional packages and unattended upgrades in line with other tasks in the role. Closes #20 